### PR TITLE
Implement dialog component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6340,7 +6340,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6362,7 +6362,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/components/ui/dialog/dialog-close.tsx
+++ b/src/components/ui/dialog/dialog-close.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+export function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}

--- a/src/components/ui/dialog/dialog-content.tsx
+++ b/src/components/ui/dialog/dialog-content.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '@/utils';
+import { DialogPortal } from './dialog-portal';
+import { DialogOverlay } from './dialog-overlay';
+
+import { XMarkIcon } from '@heroicons/react/24/solid';
+
+export function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+          <XMarkIcon className="h-6 w-6 text-gray-500" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}

--- a/src/components/ui/dialog/dialog-content.tsx
+++ b/src/components/ui/dialog/dialog-content.tsx
@@ -20,14 +20,14 @@ export function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg duration-200 sm:max-w-lg',
           className
         )}
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XMarkIcon className="h-6 w-6 text-gray-500" />
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-background-muted data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-lg opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5">
+          <XMarkIcon className="h-6 w-6 text-black" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>

--- a/src/components/ui/dialog/dialog-description.tsx
+++ b/src/components/ui/dialog/dialog-description.tsx
@@ -12,7 +12,7 @@ export function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-secondary text-sm', className)}
       {...props}
     />
   );

--- a/src/components/ui/dialog/dialog-description.tsx
+++ b/src/components/ui/dialog/dialog-description.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '@/utils';
+
+export function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/dialog/dialog-footer.tsx
+++ b/src/components/ui/dialog/dialog-footer.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/utils';
+
+export function DialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/dialog/dialog-header.tsx
+++ b/src/components/ui/dialog/dialog-header.tsx
@@ -11,7 +11,7 @@ export function DialogHeader({
     <div
       data-slot="dialog-header"
       className={cn(
-        'text-foreground flex flex-col gap-2 sm:text-left',
+        'text-foreground flex flex-col gap-2 text-center sm:text-left',
         className
       )}
       {...props}

--- a/src/components/ui/dialog/dialog-header.tsx
+++ b/src/components/ui/dialog/dialog-header.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/utils';
+
+export function DialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/dialog/dialog-header.tsx
+++ b/src/components/ui/dialog/dialog-header.tsx
@@ -10,7 +10,10 @@ export function DialogHeader({
   return (
     <div
       data-slot="dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      className={cn(
+        'text-foreground flex flex-col gap-2 sm:text-left',
+        className
+      )}
       {...props}
     />
   );

--- a/src/components/ui/dialog/dialog-overlay.tsx
+++ b/src/components/ui/dialog/dialog-overlay.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '@/utils';
+
+export function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn('fixed inset-0 z-50 bg-black/80', className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/dialog/dialog-portal.tsx
+++ b/src/components/ui/dialog/dialog-portal.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+export function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}

--- a/src/components/ui/dialog/dialog-title.tsx
+++ b/src/components/ui/dialog/dialog-title.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '@/utils';
+
+export function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        'text-foreground leading-none font-semibold tracking-tight',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/dialog/dialog-title.tsx
+++ b/src/components/ui/dialog/dialog-title.tsx
@@ -13,7 +13,7 @@ export function DialogTitle({
     <DialogPrimitive.Title
       data-slot="dialog-title"
       className={cn(
-        'text-foreground leading-none font-semibold tracking-tight',
+        'text-foreground text-lg leading-none font-medium tracking-tight',
         className
       )}
       {...props}

--- a/src/components/ui/dialog/dialog-trigger.tsx
+++ b/src/components/ui/dialog/dialog-trigger.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+export function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}

--- a/src/components/ui/dialog/dialog.tsx
+++ b/src/components/ui/dialog/dialog.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+export function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}

--- a/src/components/ui/dialog/index.ts
+++ b/src/components/ui/dialog/index.ts
@@ -1,0 +1,10 @@
+export { Dialog } from './dialog';
+export { DialogPortal } from './dialog-portal';
+export { DialogOverlay } from './dialog-overlay';
+export { DialogTrigger } from './dialog-trigger';
+export { DialogClose } from './dialog-close';
+export { DialogContent } from './dialog-content';
+export { DialogHeader } from './dialog-header';
+export { DialogFooter } from './dialog-footer';
+export { DialogTitle } from './dialog-title';
+export { DialogDescription } from './dialog-description';


### PR DESCRIPTION
# Changes
- removed `dialog-content.tsx`: animation 
- changed `dialog-content.tsx`: `rounded-lg` to `rounded-xl`
- changed `dialog-content.tsx`: `bg-accent` to `bg-background-muted`
- changed `dialog-content.tsx`: `XIcon` to `XMarkIcon` from heroicons

Addendum: After running `pnpm add @radix-ui/react-dialog` the `pnpm-lock.yaml` file changed something regarding the eslint-module, dunno if this is intended

# Pictures:
dialog closed:
![dialog-unopened](https://github.com/user-attachments/assets/47957943-e760-43d0-b4e4-1a3cb760345e)

dialog opened:
![dialog-opened](https://github.com/user-attachments/assets/aec28bc2-d5e8-46d2-8593-8e2a01028fb4)

dialog with additional fields opened:
![dialog-complex-opened](https://github.com/user-attachments/assets/4598e548-acd2-4b7b-ab5d-187d63d146dd)
