### PR TITLE
Request first and last name upon signup and save those values to the database

### DIFF
--- a/src/components/forms/register.tsx
+++ b/src/components/forms/register.tsx
@@ -90,32 +90,34 @@ export function RegisterForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <FormField
-          control={form.control}
-          name="firstName"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Vorname</FormLabel>
-              <FormControl>
-                <Input type="text" placeholder="Max" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="lastName"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Nachname</FormLabel>
-              <FormControl>
-                <Input type="text" placeholder="Mustermann" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <div className="grid gap-8 lg:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="firstName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Vorname</FormLabel>
+                <FormControl>
+                  <Input type="text" placeholder="Max" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="lastName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nachname</FormLabel>
+                <FormControl>
+                  <Input type="text" placeholder="Mustermann" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
         <FormField
           control={form.control}
           name="email"

--- a/src/components/forms/register.tsx
+++ b/src/components/forms/register.tsx
@@ -67,6 +67,8 @@ export function RegisterForm() {
   const form = useForm<z.infer<typeof signUpSchema>>({
     resolver: zodResolver(signUpSchema),
     defaultValues: {
+      firstName: '',
+      lastName: '',
       email: '',
       password: '',
     },
@@ -88,6 +90,32 @@ export function RegisterForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="firstName"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Vorname</FormLabel>
+              <FormControl>
+                <Input type="text" placeholder="Max" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="lastName"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nachname</FormLabel>
+              <FormControl>
+                <Input type="text" placeholder="Mustermann" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
         <FormField
           control={form.control}
           name="email"

--- a/src/server/actions/auth.ts
+++ b/src/server/actions/auth.ts
@@ -33,7 +33,7 @@ export async function signup({
     };
   }
 
-  const res = await signUpWithEmail(firstName, lastName, email, password);
+  const res = await signUpWithEmail({ firstName, lastName, email, password });
 
   if (!res.ok) {
     return {

--- a/src/server/actions/auth.ts
+++ b/src/server/actions/auth.ts
@@ -11,20 +11,10 @@ import { redirect } from 'next/navigation';
 import * as authService from '../services/auth';
 import { AuthActionResponse } from '../types/action-response';
 
-export async function signup({
-  firstName,
-  lastName,
-  email,
-  password,
-  acceptLegal,
-}: SignUpData): Promise<AuthActionResponse<null>> {
-  const parseRes = await signUpSchema.safeParseAsync({
-    firstName,
-    lastName,
-    email,
-    password,
-    acceptLegal,
-  });
+export async function signup(
+  signUpData: SignUpData
+): Promise<AuthActionResponse<null>> {
+  const parseRes = await signUpSchema.safeParseAsync(signUpData);
 
   if (!parseRes.success) {
     return {
@@ -33,7 +23,7 @@ export async function signup({
     };
   }
 
-  const res = await signUpWithEmail({ firstName, lastName, email, password });
+  const res = await signUpWithEmail(signUpData);
 
   if (!res.ok) {
     return {

--- a/src/server/actions/auth.ts
+++ b/src/server/actions/auth.ts
@@ -12,11 +12,15 @@ import * as authService from '../services/auth';
 import { AuthActionResponse } from '../types/action-response';
 
 export async function signup({
+  firstName,
+  lastName,
   email,
   password,
   acceptLegal,
 }: SignUpData): Promise<AuthActionResponse<null>> {
   const parseRes = await signUpSchema.safeParseAsync({
+    firstName,
+    lastName,
     email,
     password,
     acceptLegal,
@@ -29,7 +33,7 @@ export async function signup({
     };
   }
 
-  const res = await signUpWithEmail(email, password);
+  const res = await signUpWithEmail(firstName, lastName, email, password);
 
   if (!res.ok) {
     return {

--- a/src/server/schemas/auth.ts
+++ b/src/server/schemas/auth.ts
@@ -50,6 +50,9 @@ const generatePasswordSchema = (): z.ZodObject<{ password: z.ZodString }> => {
 
 export const signUpSchema = z
   .object({
+    // Should names be limited to ASCII characters?
+    firstName: z.string({ message: 'Vorname darf nur Buchstaben enthalten' }),
+    lastName: z.string({ message: 'Nachname darf nur Buchstaben enthalten' }),
     email: z.string().email('Ungültige E-Mail-Adresse'),
     acceptLegal: z
       .boolean({

--- a/src/server/schemas/auth.ts
+++ b/src/server/schemas/auth.ts
@@ -51,8 +51,8 @@ const generatePasswordSchema = (): z.ZodObject<{ password: z.ZodString }> => {
 export const signUpSchema = z
   .object({
     // Should names be limited to ASCII characters?
-    firstName: z.string({ message: 'Vorname darf nur Buchstaben enthalten' }),
-    lastName: z.string({ message: 'Nachname darf nur Buchstaben enthalten' }),
+    firstName: z.string().min(1, 'Der Vorname wird benötigt'),
+    lastName: z.string().min(1, 'Der Vorname wird benötigt'),
     email: z.string().email('Ungültige E-Mail-Adresse'),
     acceptLegal: z
       .boolean({

--- a/src/server/services/auth.ts
+++ b/src/server/services/auth.ts
@@ -6,6 +6,7 @@ import type { Session, SupabaseClient, User } from '@supabase/supabase-js';
 import { randomBytes } from 'crypto';
 import prisma from '../db';
 import { ServiceResult } from '../types/serviceResult';
+import { SignUpData } from '../schemas/auth';
 
 /**
  * Signs up a new user with email and password.
@@ -18,40 +19,23 @@ import { ServiceResult } from '../types/serviceResult';
  * @returns A promise with the status of the sign up.
  */
 
-interface UserRegistration {
-  firstName: string;
-  lastName: string;
-  email: string;
-  password: string;
-}
-
 export async function signUpWithEmail(
-  userReg: UserRegistration
+  signUpData: SignUpData
 ): Promise<ServiceResult<{ user: User | null; session: Session | null }>> {
-  if (
-    !userReg.firstName ||
-    !userReg.lastName ||
-    !userReg.email ||
-    !userReg.password
-  ) {
+  const { firstName, lastName, email, password } = signUpData;
+
+  if (!firstName || !lastName || !email || !password) {
     return {
       ok: false,
-      error: 'Your full Name, email and password are required for singup.',
+      error: 'Your full Name, email and password are required for signup.',
     };
   }
 
   const client = await createClient();
 
   const { error, data } = await client.auth.signUp({
-    email: userReg.email,
-    password: userReg.password,
-    // Is adding the data object necessary, since we create the user profile with prisma?
-    options: {
-      data: {
-        firstName: userReg.firstName,
-        lastName: userReg.lastName,
-      },
-    },
+    email: email,
+    password: password,
   });
 
   if (error || !data?.user) {
@@ -70,11 +54,11 @@ export async function signUpWithEmail(
     data: {
       id: data.user.id,
       role: 'USER',
-      email: userReg.email,
+      email: email,
       userProfile: {
         create: {
-          firstName: userReg.firstName,
-          lastName: userReg.lastName,
+          firstName: firstName,
+          lastName: lastName,
           emailReminders: false,
           notifyMe: false,
         },

--- a/src/server/services/auth.ts
+++ b/src/server/services/auth.ts
@@ -63,8 +63,8 @@ export async function signUpWithEmail(
       email: email,
       userProfile: {
         create: {
-          firstName: '',
-          lastName: '',
+          firstName: firstName,
+          lastName: lastName,
           emailReminders: false,
           notifyMe: false,
         },

--- a/src/server/services/auth.ts
+++ b/src/server/services/auth.ts
@@ -10,17 +10,24 @@ import { ServiceResult } from '../types/serviceResult';
 /**
  * Signs up a new user with email and password.
  *
+ * @param firstName - The first name of the user.
+ * @param lastName - The last name of the user.
  * @param email - The email of the user.
  * @param password - The password of the user.
  *
  * @returns A promise with the status of the sign up.
  */
 export async function signUpWithEmail(
+  firstName: string,
+  lastName: string,
   email: string,
   password: string
 ): Promise<ServiceResult<{ user: User | null; session: Session | null }>> {
-  if (!email || !password) {
-    return { ok: false, error: 'Email and password are required for singup.' };
+  if (!firstName || !lastName || !email || !password) {
+    return {
+      ok: false,
+      error: 'Your full Name, email and password are required for singup.',
+    };
   }
 
   const client = await createClient();
@@ -28,6 +35,13 @@ export async function signUpWithEmail(
   const { error, data } = await client.auth.signUp({
     email,
     password,
+    // Is adding the data object necessary, since we create the user profile with prisma?
+    options: {
+      data: {
+        firstName,
+        lastName,
+      },
+    },
   });
 
   if (error || !data?.user) {

--- a/src/server/services/auth.ts
+++ b/src/server/services/auth.ts
@@ -17,13 +17,23 @@ import { ServiceResult } from '../types/serviceResult';
  *
  * @returns A promise with the status of the sign up.
  */
+
+interface UserRegistration {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+}
+
 export async function signUpWithEmail(
-  firstName: string,
-  lastName: string,
-  email: string,
-  password: string
+  userReg: UserRegistration
 ): Promise<ServiceResult<{ user: User | null; session: Session | null }>> {
-  if (!firstName || !lastName || !email || !password) {
+  if (
+    !userReg.firstName ||
+    !userReg.lastName ||
+    !userReg.email ||
+    !userReg.password
+  ) {
     return {
       ok: false,
       error: 'Your full Name, email and password are required for singup.',
@@ -33,13 +43,13 @@ export async function signUpWithEmail(
   const client = await createClient();
 
   const { error, data } = await client.auth.signUp({
-    email,
-    password,
+    email: userReg.email,
+    password: userReg.password,
     // Is adding the data object necessary, since we create the user profile with prisma?
     options: {
       data: {
-        firstName,
-        lastName,
+        firstName: userReg.firstName,
+        lastName: userReg.lastName,
       },
     },
   });
@@ -60,11 +70,11 @@ export async function signUpWithEmail(
     data: {
       id: data.user.id,
       role: 'USER',
-      email: email,
+      email: userReg.email,
       userProfile: {
         create: {
-          firstName: firstName,
-          lastName: lastName,
+          firstName: userReg.firstName,
+          lastName: userReg.lastName,
           emailReminders: false,
           notifyMe: false,
         },


### PR DESCRIPTION
# Notes
- can't remove users from supabase authentication table via dashboard
- should I create a global/local interface for signUp which I export to both auth files?

# Changes
- added firstName and lastName variables to signUpSchema, services/auth.ts, actions/auth.ts
- added form for first and lastName variables
- tried different versions of passing objects as arguments

# Pictures
**.../auth/register**
![image](https://github.com/user-attachments/assets/87617f0f-0d61-4d29-80dc-593f84ed4d9b)

**Nothing entered**
![image](https://github.com/user-attachments/assets/e12441ae-a72e-458e-8ba5-1993f97814d7)

**Only firstName and lastName are NOT entered**
![image](https://github.com/user-attachments/assets/1da0a303-0ab2-4c84-b029-5159353aee9a)

**Database Before Registration**
![image](https://github.com/user-attachments/assets/7942b03b-ad5d-4a08-8e44-c5dabece88df)

**Database After Registration**
![image](https://github.com/user-attachments/assets/878f1963-474f-40b5-98f1-a0c4ad231036)
![image](https://github.com/user-attachments/assets/3566bce9-96cd-44aa-b801-705b25549a0e)


